### PR TITLE
Add meta viewport to "Unicode in 5 minutes" HTML

### DIFF
--- a/unicode-in-five-minutes.html
+++ b/unicode-in-five-minutes.html
@@ -3,6 +3,7 @@
 <head>
         <title>Unicode In Five Minutes ⌚</title>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./theme/css/main.css" type="text/css" />
                 <link href="http://richardharr.is/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="richardharr.is Atom Feed" />
                 


### PR DESCRIPTION
Since this meta tag was missing it was difficult to read this post on mobile since browsers assume a larger viewport size. See: [https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag)